### PR TITLE
Refactor dataset generation and rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ Undistortion is implemented as a simple fixed-point iteration starting from `(xu
 ## Current state
 
 The `generate` subcommand currently writes:
-- output folder structure
 - `config.yaml` (the normalized config used to generate)
 - `manifest.yaml` (stable schema v1)
-- placeholder rig/camera YAML files
+- per-frame `T_base_tcp.npy` (currently identity for all frames, v0)
+- per-frame/per-camera `*_target.png` + `*_corners_*.npy`
+- placeholder rig/camera YAML files (`rig/`)
 
-Rendering of images and ground-truth arrays will be added next.
+Laser/stripe rendering is not implemented yet.
 
 ## CLI
 
@@ -55,15 +56,24 @@ Create an output directory with manifest + placeholders:
 python -m synthcal generate config.yaml out_dataset/
 ```
 
+Preview one frame/camera with a matplotlib overlay:
+
+```bash
+python -m synthcal preview config.yaml --frame 0 --cam cam00
+```
+
 ## Output format (planned)
 
 The dataset layout is described in `manifest.yaml`. The v1 layout patterns include:
-- `frames/frame_{frame_index:06d}/cam_{camera_name}/target.png`
-- `frames/frame_{frame_index:06d}/cam_{camera_name}/corners_px.npy`
-- `frames/frame_{frame_index:06d}/cam_{camera_name}/corners_visible.npy`
+- `frames/frame_{frame_index:06d}/{camera_name}_target.png`
+- `frames/frame_{frame_index:06d}/{camera_name}_corners_px.npy`
+- `frames/frame_{frame_index:06d}/{camera_name}_corners_visible.npy`
 
-When `laser.enabled: true` in the config, the manifest additionally lists:
-- `frames/frame_{frame_index:06d}/cam_{camera_name}/stripe.png`
-- `frames/frame_{frame_index:06d}/cam_{camera_name}/stripe_centerline_px.npy`
+Additional files created per frame (not currently described by the manifest):
+- `frames/frame_{frame_index:06d}/T_base_tcp.npy`
 
-For v0, the generator creates the `frames/` folder and per-frame/per-camera directories but does not yet render the files.
+## Coordinate conventions
+
+- `T_cam_target` maps target-frame points into the camera frame: `X_cam = T_cam_target @ [X_target, 1]`.
+- The chessboard target lies in plane `Z=0` in the target frame, with outer corner at `(0,0,0)`.
+- Inner corners are ordered row-major (rows first, then cols), matching OpenCV’s convention.

--- a/src/synthcal/core/geometry.py
+++ b/src/synthcal/core/geometry.py
@@ -67,3 +67,21 @@ def transform_points(T: Any, points: Any) -> np.ndarray:
         raise ValueError(f"points must have shape (3,) or (..., 3), got {pts.shape}")
     return pts @ T[:3, :3].T + T[:3, 3]
 
+
+def invert_se3(T: Any) -> np.ndarray:
+    """Invert an SE(3) transform.
+
+    Uses the SE(3) structure:
+        T = [[R, t],
+             [0, 1]]
+        T^{-1} = [[R^T, -R^T t],
+                  [0,    1]]
+    """
+
+    T = as_se3(T)
+    R = T[:3, :3]
+    t = T[:3, 3]
+    T_inv = np.eye(4, dtype=np.float64)
+    T_inv[:3, :3] = R.T
+    T_inv[:3, 3] = -R.T @ t
+    return T_inv

--- a/src/synthcal/io/generate.py
+++ b/src/synthcal/io/generate.py
@@ -1,0 +1,181 @@
+"""Dataset generation (v0).
+
+This module currently supports generating:
+- a rendered chessboard image per frame/camera
+- ground-truth inner corner projections + visibility mask per frame/camera
+
+Laser/stripe rendering is intentionally not implemented yet.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+from synthcal import __version__
+from synthcal.camera import PinholeCamera
+from synthcal.core.geometry import invert_se3
+from synthcal.io.config import SynthCalConfig, save_config
+from synthcal.io.manifest import (
+    ManifestCamera,
+    ManifestGenerator,
+    ManifestLayout,
+    ManifestPaths,
+    SynthCalManifest,
+    save_manifest,
+    utc_now_iso8601,
+)
+from synthcal.render.chessboard import render_chessboard_image
+from synthcal.render.gt import project_corners_px
+from synthcal.targets.chessboard import ChessboardTarget
+
+
+def _mat44(value: Any) -> np.ndarray:
+    arr = np.asarray(value, dtype=np.float64)
+    if arr.shape != (4, 4):
+        raise ValueError(f"Expected 4x4 matrix, got {arr.shape}")
+    return arr
+
+
+def _default_T_world_target(target: ChessboardTarget) -> np.ndarray:
+    """Default target pose that is fronto-parallel and centered in view."""
+
+    width_mm, height_mm = target.bounds()
+    T = np.eye(4, dtype=np.float64)
+    T[:3, 3] = np.array([-width_mm / 2.0, -height_mm / 2.0, 1000.0], dtype=np.float64)
+    return T
+
+
+def _yaml_dump(data: object) -> str:
+    import yaml
+
+    return yaml.safe_dump(
+        data,
+        sort_keys=False,
+        indent=2,
+        default_flow_style=False,
+    )
+
+
+def _write_rig_files(cfg: SynthCalConfig, out_dir: Path) -> None:
+    rig_dir = out_dir / "rig"
+    cams_dir = rig_dir / "cameras"
+    cams_dir.mkdir(parents=True, exist_ok=True)
+
+    rig_yaml = {
+        "version": 1,
+        "units": {"length": "mm"},
+        "cameras": [
+            {
+                "name": cam.name,
+                "intrinsics_yaml": f"cameras/{cam.name}.yaml",
+                "T_tcp_cam": [list(row) for row in cam.T_tcp_cam],
+            }
+            for cam in cfg.rig.cameras
+        ],
+        "notes": "Placeholder rig file (v0).",
+    }
+    (rig_dir / "rig.yaml").write_text(_yaml_dump(rig_yaml), encoding="utf-8")
+
+    for cam in cfg.rig.cameras:
+        (cams_dir / f"{cam.name}.yaml").write_text(
+            _yaml_dump(
+                {
+                    "version": 1,
+                    "name": cam.name,
+                    "image_size_px": [cam.image_size_px[0], cam.image_size_px[1]],
+                    "K": [list(row) for row in cam.K],
+                    "dist": list(cam.dist),
+                    "notes": "Placeholder intrinsics file (v0).",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+
+def generate_dataset(cfg: SynthCalConfig, out_dir: str | Path) -> None:
+    """Generate a dataset on disk."""
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if cfg.laser is not None and cfg.laser.enabled:
+        print(
+            "note: laser enabled but stripe rendering not implemented yet (will be added in next milestone)",
+            file=sys.stderr,
+        )
+
+    # Persist the normalized config used for generation.
+    save_config(cfg, out_dir / "config.yaml")
+    _write_rig_files(cfg, out_dir)
+
+    # Build camera/target models.
+    cols, rows = cfg.chessboard.inner_corners
+    target = ChessboardTarget(inner_rows=rows, inner_cols=cols, square_size_mm=cfg.chessboard.square_size_mm)
+    corners_xyz = target.corners_xyz()
+
+    if cfg.scene is not None:
+        T_world_target = _mat44(cfg.scene.T_world_target)
+    else:
+        T_world_target = _default_T_world_target(target)
+
+    frames_dir = out_dir / "frames"
+    frames_dir.mkdir(parents=True, exist_ok=True)
+
+    # For v0, use a single static TCP pose for all frames (identity).
+    T_base_tcp = np.eye(4, dtype=np.float64)
+
+    for frame_index in range(cfg.dataset.num_frames):
+        frame_dir = frames_dir / f"frame_{frame_index:06d}"
+        frame_dir.mkdir(parents=True, exist_ok=True)
+        np.save(frame_dir / "T_base_tcp.npy", T_base_tcp)
+
+        for cam_cfg in cfg.rig.cameras:
+            cam = PinholeCamera(
+                resolution=cam_cfg.image_size_px,
+                K=np.asarray(cam_cfg.K, dtype=np.float64),
+                dist=np.asarray(cam_cfg.dist, dtype=np.float64),
+            )
+
+            T_tcp_cam = _mat44(cam_cfg.T_tcp_cam)
+            T_world_cam = T_base_tcp @ T_tcp_cam
+            T_cam_target = invert_se3(T_world_cam) @ T_world_target
+
+            img = render_chessboard_image(cam, target, T_cam_target)
+            Image.fromarray(img, mode="L").save(frame_dir / f"{cam_cfg.name}_target.png")
+
+            corners_px, visible = project_corners_px(cam, corners_xyz, T_cam_target)
+            np.save(frame_dir / f"{cam_cfg.name}_corners_px.npy", corners_px.astype(np.float32, copy=False))
+            np.save(frame_dir / f"{cam_cfg.name}_corners_visible.npy", visible.astype(bool, copy=False))
+
+    # Write a v1 manifest that lists only outputs produced in v0.
+    manifest = SynthCalManifest(
+        manifest_version=1,
+        created_utc=utc_now_iso8601(),
+        generator=ManifestGenerator(name="synthcal", version=__version__),
+        seed=cfg.seed,
+        units={"length": "mm"},
+        dataset={"name": cfg.dataset.name, "num_frames": cfg.dataset.num_frames},
+        laser=None,
+        paths=ManifestPaths(
+            config_yaml="config.yaml",
+            manifest_yaml="manifest.yaml",
+            rig_yaml="rig/rig.yaml",
+            cameras_dir="rig/cameras",
+            frames_dir="frames",
+        ),
+        cameras=tuple(
+            ManifestCamera(
+                name=c.name,
+                intrinsics_yaml=f"rig/cameras/{c.name}.yaml",
+                image_size_px=c.image_size_px,
+            )
+            for c in cfg.rig.cameras
+        ),
+        layout=ManifestLayout.v1_default(include_laser=False),
+    )
+    save_manifest(manifest, out_dir / "manifest.yaml")

--- a/src/synthcal/io/manifest.py
+++ b/src/synthcal/io/manifest.py
@@ -183,18 +183,20 @@ class ManifestLayout:
     stripe_centerline_px_npy: str | None = None
 
     @classmethod
-    def v1_default(cls, *, include_laser: bool) -> "ManifestLayout":
+    def v1_default(cls, *, include_laser: bool = False) -> "ManifestLayout":
         frame_dir = "frames/frame_{frame_index:06d}"
-        camera_dir = "cam_{camera_name}"
-        base = f"{frame_dir}/{camera_dir}"
+        camera_dir = "."
+        base = frame_dir
         return cls(
             frame_dir=frame_dir,
             camera_dir=camera_dir,
-            target_image=f"{base}/target.png",
-            corners_px_npy=f"{base}/corners_px.npy",
-            corners_visible_npy=f"{base}/corners_visible.npy",
-            stripe_image=(f"{base}/stripe.png" if include_laser else None),
-            stripe_centerline_px_npy=(f"{base}/stripe_centerline_px.npy" if include_laser else None),
+            target_image=f"{base}/{{camera_name}}_target.png",
+            corners_px_npy=f"{base}/{{camera_name}}_corners_px.npy",
+            corners_visible_npy=f"{base}/{{camera_name}}_corners_visible.npy",
+            stripe_image=(f"{base}/{{camera_name}}_stripe.png" if include_laser else None),
+            stripe_centerline_px_npy=(
+                f"{base}/{{camera_name}}_stripe_centerline_px.npy" if include_laser else None
+            ),
         )
 
     @classmethod

--- a/src/synthcal/render/__init__.py
+++ b/src/synthcal/render/__init__.py
@@ -1,0 +1,4 @@
+"""Rendering and ground-truth helpers."""
+
+from __future__ import annotations
+

--- a/src/synthcal/render/chessboard.py
+++ b/src/synthcal/render/chessboard.py
@@ -1,0 +1,99 @@
+"""Analytic planar chessboard rendering (no OpenCV dependency)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from synthcal.camera import PinholeCamera
+from synthcal.core.geometry import as_se3
+from synthcal.targets import ChessboardTarget
+
+
+def render_chessboard_image(
+    camera: PinholeCamera,
+    target: ChessboardTarget,
+    T_cam_target: Any,
+    *,
+    background: int = 128,
+    supersample: int = 1,
+) -> np.ndarray:
+    """Render a chessboard target into a grayscale image.
+
+    Parameters
+    ----------
+    camera:
+        Pinhole camera model.
+    target:
+        Chessboard target model (plane Z=0 in target frame).
+    T_cam_target:
+        SE(3) transform mapping target-frame points into camera frame.
+    background:
+        Background grayscale intensity (0..255).
+    supersample:
+        Placeholder for future antialiasing. Only `1` is supported in v0.
+
+    Returns
+    -------
+    np.ndarray
+        Image array of shape `(H, W)` with dtype `uint8`.
+    """
+
+    if not (0 <= background <= 255):
+        raise ValueError("background must be in [0, 255]")
+    if supersample != 1:
+        raise NotImplementedError("supersample != 1 is not implemented yet")
+
+    width_px, height_px = camera.resolution
+    H, W = int(height_px), int(width_px)
+
+    T = as_se3(T_cam_target)
+    R = T[:3, :3]
+    t = T[:3, 3]
+
+    n = R @ np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    numerator = float(np.dot(n, t))
+
+    Kinv = np.linalg.inv(camera.K)
+
+    u = np.arange(W, dtype=np.float64)
+    v = np.arange(H, dtype=np.float64)
+    uu, vv = np.meshgrid(u, v)  # (H, W)
+    uu_f = uu.reshape(-1)
+    vv_f = vv.reshape(-1)
+
+    uv1 = np.stack([uu_f, vv_f, np.ones_like(uu_f)], axis=0)  # (3, N)
+    xy1 = Kinv @ uv1
+    xd = xy1[0] / xy1[2]
+    yd = xy1[1] / xy1[2]
+
+    xu, yu = camera.undistort_normalized(xd, yd)
+    xu = np.asarray(xu, dtype=np.float64).reshape(-1)
+    yu = np.asarray(yu, dtype=np.float64).reshape(-1)
+
+    d = np.stack([xu, yu, np.ones_like(xu)], axis=0)  # (3, N)
+    denom = (n.reshape(1, 3) @ d).reshape(-1)  # (N,)
+
+    eps_denom = 1e-12
+    denom_ok = np.abs(denom) > eps_denom
+
+    t_ray = np.full_like(denom, np.nan, dtype=np.float64)
+    t_ray[denom_ok] = numerator / denom[denom_ok]
+    valid = denom_ok & (t_ray > 0.0)
+
+    X_cam = d * t_ray.reshape(1, -1)  # (3, N) with NaNs for invalid rays
+    X_target = R.T @ (X_cam - t.reshape(3, 1))  # (3, N)
+
+    x = X_target[0]
+    y = X_target[1]
+
+    width_mm, height_mm = target.bounds()
+    inside = (x >= 0.0) & (x < width_mm) & (y >= 0.0) & (y < height_mm)
+    mask = valid & inside
+
+    out = np.full(W * H, background, dtype=np.uint8)
+    if bool(np.any(mask)):
+        out[mask] = target.eval_color_xy(x[mask], y[mask])
+    return out.reshape(H, W)
+

--- a/src/synthcal/render/gt.py
+++ b/src/synthcal/render/gt.py
@@ -1,0 +1,58 @@
+"""Ground-truth projection helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from synthcal.camera import PinholeCamera
+from synthcal.core.geometry import as_se3
+
+
+def project_corners_px(
+    camera: PinholeCamera,
+    corners_xyz_target: np.ndarray,
+    T_cam_target: Any,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Project target-frame points into the image.
+
+    Visibility (v0) is defined as:
+    - point in front: `z_cam > 0`
+    - projected pixel inside image bounds
+    - finite pixel values
+    """
+
+    corners = np.asarray(corners_xyz_target, dtype=np.float64)
+    if corners.ndim != 2 or corners.shape[1] != 3:
+        raise ValueError(f"corners_xyz_target must have shape (N, 3), got {corners.shape}")
+
+    T = as_se3(T_cam_target)
+    R = T[:3, :3]
+    t = T[:3, 3]
+
+    # X_cam = R * X_target + t (row-vector form)
+    X_cam = corners @ R.T + t
+    z = X_cam[:, 2]
+
+    behind = z <= 0.0
+    x = np.full_like(z, np.nan, dtype=np.float64)
+    y = np.full_like(z, np.nan, dtype=np.float64)
+
+    ok = ~behind
+    x[ok] = X_cam[ok, 0] / z[ok]
+    y[ok] = X_cam[ok, 1] / z[ok]
+
+    xd, yd = camera.distort_normalized(x, y)
+    u, v = camera.normalized_to_pixel(xd, yd)
+    u = np.asarray(u, dtype=np.float64)
+    v = np.asarray(v, dtype=np.float64)
+
+    corners_px = np.stack([u, v], axis=1).astype(np.float32, copy=False)
+
+    W, H = camera.resolution
+    finite = np.isfinite(u) & np.isfinite(v)
+    in_bounds = (u >= 0.0) & (u < float(W)) & (v >= 0.0) & (v < float(H))
+    visible = ok & finite & in_bounds
+    return corners_px, visible.astype(bool, copy=False)
+

--- a/src/synthcal/targets/__init__.py
+++ b/src/synthcal/targets/__init__.py
@@ -1,0 +1,8 @@
+"""Synthetic calibration targets."""
+
+from __future__ import annotations
+
+from .chessboard import ChessboardTarget
+
+__all__ = ["ChessboardTarget"]
+

--- a/src/synthcal/targets/chessboard.py
+++ b/src/synthcal/targets/chessboard.py
@@ -1,0 +1,94 @@
+"""Chessboard calibration target model.
+
+Coordinate system (target frame)
+-------------------------------
+- The chessboard lies in the plane `Z=0`.
+- The outer corner of the board is at `(0, 0, 0)`.
+- `+X` increases to the right across columns.
+- `+Y` increases downward across rows.
+
+Inner corners follow OpenCV convention and are returned in row-major order:
+for `j` in rows (0..inner_rows-1), for `i` in cols (0..inner_cols-1).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ChessboardTarget:
+    """A planar chessboard target (inner corners only)."""
+
+    inner_rows: int
+    inner_cols: int
+    square_size_mm: float
+    border_squares: int = 0
+    colors: tuple[int, int] = (0, 255)
+
+    def __post_init__(self) -> None:
+        if self.inner_rows <= 0 or self.inner_cols <= 0:
+            raise ValueError("inner_rows and inner_cols must be > 0")
+        if self.square_size_mm <= 0:
+            raise ValueError("square_size_mm must be > 0")
+        if self.border_squares < 0:
+            raise ValueError("border_squares must be >= 0")
+        if len(self.colors) != 2:
+            raise ValueError("colors must be a pair (black, white)")
+        for c in self.colors:
+            if not isinstance(c, int) or not (0 <= c <= 255):
+                raise ValueError("colors must be integers in [0, 255]")
+
+    @property
+    def num_corners(self) -> int:
+        return self.inner_rows * self.inner_cols
+
+    def bounds(self) -> tuple[float, float]:
+        """Return `(width_mm, height_mm)` of the board (including optional border)."""
+
+        cols_squares = (self.inner_cols + 1) + 2 * self.border_squares
+        rows_squares = (self.inner_rows + 1) + 2 * self.border_squares
+        return cols_squares * self.square_size_mm, rows_squares * self.square_size_mm
+
+    def corners_xyz(self) -> np.ndarray:
+        """Return inner corner locations in the target frame, shape `(N, 3)` float64."""
+
+        s = float(self.square_size_mm)
+        x0 = (self.border_squares + 1) * s
+        y0 = (self.border_squares + 1) * s
+
+        xs = x0 + np.arange(self.inner_cols, dtype=np.float64) * s
+        ys = y0 + np.arange(self.inner_rows, dtype=np.float64) * s
+        xx, yy = np.meshgrid(xs, ys)  # (rows, cols)
+        corners = np.stack([xx.reshape(-1), yy.reshape(-1), np.zeros(self.num_corners)], axis=1)
+        return corners.astype(np.float64, copy=False)
+
+    def eval_color_xy(self, x_mm: Any, y_mm: Any) -> np.ndarray:
+        """Evaluate chessboard color at point(s) on the plane.
+
+        Parameters
+        ----------
+        x_mm, y_mm:
+            Coordinates in the target plane (mm). Scalars or arrays are accepted.
+
+        Returns
+        -------
+        np.ndarray
+            `uint8` values with the same broadcasted shape as inputs.
+        """
+
+        x = np.asarray(x_mm, dtype=np.float64)
+        y = np.asarray(y_mm, dtype=np.float64)
+        x, y = np.broadcast_arrays(x, y)
+
+        s = float(self.square_size_mm)
+        ix = np.floor(x / s).astype(np.int64)
+        iy = np.floor(y / s).astype(np.int64)
+
+        is_black = ((ix + iy) & 1) == 0
+        black, white = self.colors
+        return np.where(is_black, black, white).astype(np.uint8, copy=False)
+

--- a/tests/test_chessboard_render.py
+++ b/tests/test_chessboard_render.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import numpy as np
+
+from synthcal.camera import PinholeCamera
+from synthcal.render.chessboard import render_chessboard_image
+from synthcal.render.gt import project_corners_px
+from synthcal.targets.chessboard import ChessboardTarget
+
+
+def test_chessboard_render_and_corner_projection() -> None:
+    cam = PinholeCamera(
+        resolution=(640, 480),
+        K=np.array([[800.0, 0.0, 320.0], [0.0, 800.0, 240.0], [0.0, 0.0, 1.0]]),
+        dist=np.zeros(5, dtype=np.float64),
+    )
+    target = ChessboardTarget(inner_rows=6, inner_cols=9, square_size_mm=25.0)
+
+    width_mm, height_mm = target.bounds()
+    T_cam_target = np.eye(4, dtype=np.float64)
+    T_cam_target[:3, 3] = np.array([-width_mm / 2.0, -height_mm / 2.0, 1000.0], dtype=np.float64)
+
+    img = render_chessboard_image(cam, target, T_cam_target, background=128)
+    assert img.dtype == np.uint8
+    assert img.shape == (480, 640)
+    assert np.unique(img).size >= 2
+
+    corners_xyz = target.corners_xyz()
+    corners_px, visible = project_corners_px(cam, corners_xyz, T_cam_target)
+    assert corners_px.shape == (target.num_corners, 2)
+    assert corners_px.dtype == np.float32
+    assert visible.shape == (target.num_corners,)
+    assert visible.dtype == bool
+    assert int(np.sum(visible)) >= target.num_corners // 2
+
+    u = corners_px[visible, 0]
+    v = corners_px[visible, 1]
+    assert np.all(u >= 0.0) and np.all(u < cam.resolution[0])
+    assert np.all(v >= 0.0) and np.all(v < cam.resolution[1])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,11 +59,14 @@ def test_generate_creates_structure_and_manifest_paths(tmp_path: Path) -> None:
     for cam in manifest.cameras:
         assert (out_dir / cam.intrinsics_yaml).is_file()
 
-    # Spot-check a couple of frame directories.
+    # Spot-check a couple of frame directories and expected outputs.
     assert (out_dir / "frames" / "frame_000000").is_dir()
     assert (out_dir / "frames" / f"frame_{cfg.dataset.num_frames - 1:06d}").is_dir()
+    assert (out_dir / "frames" / "frame_000000" / "T_base_tcp.npy").is_file()
     for cam in cfg.rig.cameras:
-        assert (out_dir / "frames" / "frame_000000" / f"cam_{cam.name}").is_dir()
+        assert (out_dir / "frames" / "frame_000000" / f"{cam.name}_target.png").is_file()
+        assert (out_dir / "frames" / "frame_000000" / f"{cam.name}_corners_px.npy").is_file()
+        assert (out_dir / "frames" / "frame_000000" / f"{cam.name}_corners_visible.npy").is_file()
 
 
 def test_generate_omits_laser_outputs_when_disabled(tmp_path: Path) -> None:


### PR DESCRIPTION
- Implemented dataset generation in `generate.py`, including rendering chessboard images and ground-truth corner projections.
- Added support for scene configuration with a target pose in `SceneConfig`.
- Updated CLI commands to include a preview option for rendering a single frame/camera.
- Enhanced the manifest structure to reflect new output formats and paths.
- Introduced new rendering functions for chessboard images and corner projections.
- Added tests for chessboard rendering and corner projection functionality.
- Updated README to reflect changes in output structure and new features.