### PR TITLE
Implement laser stripe rendering functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repository focuses on:
 - Generating datasets of **static robot poses** for an **eye-in-hand multi-camera rig**.
 - For each frame and camera, producing paired outputs from the **same pose**:
   1) `target.png`: chessboard under normal illumination
-  2) `stripe.png`: black background with only a laser stripe
+  2) `stripe.png`: black background with only a laser stripe (when laser is enabled)
   3) `corners_px.npy` (`float32`, `N x 2`) + `corners_visible.npy` (`bool`, `N`)
-  4) `stripe_centerline_px.npy` (`float32`, `M x 2`)
+  4) `stripe_centerline_px.npy` (`float32`, `M x 2`) + `stripe_centerline_visible.npy` (`bool`, `M`)
 
 **Units:** millimeters (mm) everywhere for geometry. Pixel coordinates are in pixels.
 
@@ -38,9 +38,8 @@ The `generate` subcommand currently writes:
 - `manifest.yaml` (stable schema v1)
 - per-frame `T_base_tcp.npy` (currently identity for all frames, v0)
 - per-frame/per-camera `*_target.png` + `*_corners_*.npy`
+- when laser is enabled: per-frame/per-camera `*_stripe.png` + `*_stripe_centerline_*.npy`
 - placeholder rig/camera YAML files (`rig/`)
-
-Laser/stripe rendering is not implemented yet.
 
 ## CLI
 
@@ -68,6 +67,10 @@ The dataset layout is described in `manifest.yaml`. The v1 layout patterns inclu
 - `frames/frame_{frame_index:06d}/{camera_name}_target.png`
 - `frames/frame_{frame_index:06d}/{camera_name}_corners_px.npy`
 - `frames/frame_{frame_index:06d}/{camera_name}_corners_visible.npy`
+- when laser is enabled:
+  - `frames/frame_{frame_index:06d}/{camera_name}_stripe.png`
+  - `frames/frame_{frame_index:06d}/{camera_name}_stripe_centerline_px.npy`
+  - `frames/frame_{frame_index:06d}/{camera_name}_stripe_centerline_visible.npy`
 
 Additional files created per frame (not currently described by the manifest):
 - `frames/frame_{frame_index:06d}/T_base_tcp.npy`

--- a/src/synthcal/camera/__init__.py
+++ b/src/synthcal/camera/__init__.py
@@ -5,4 +5,3 @@ from __future__ import annotations
 from .model import PinholeCamera
 
 __all__ = ["PinholeCamera"]
-

--- a/src/synthcal/camera/model.py
+++ b/src/synthcal/camera/model.py
@@ -64,7 +64,9 @@ class PinholeCamera:
         object.__setattr__(self, "K", K)
         object.__setattr__(self, "dist", dist)
 
-    def pixel_to_normalized(self, u_px: float | np.ndarray, v_px: float | np.ndarray) -> tuple[Any, Any]:
+    def pixel_to_normalized(
+        self, u_px: float | np.ndarray, v_px: float | np.ndarray
+    ) -> tuple[Any, Any]:
         """Convert pixel coordinates to normalized coordinates using `K^{-1}`."""
 
         u = _as_float64_array(u_px)
@@ -187,4 +189,3 @@ class PinholeCamera:
         xd, yd = self.distort_normalized(x, y)
         u, v = self.normalized_to_pixel(xd, yd)
         return float(u), float(v), False
-

--- a/src/synthcal/cli.py
+++ b/src/synthcal/cli.py
@@ -30,8 +30,15 @@ def _cmd_preview(config_path: Path, *, frame_index: int, camera_name: str | None
 
     from synthcal.camera import PinholeCamera
     from synthcal.core.geometry import invert_se3
+    from synthcal.laser import (
+        intersect_planes_to_line,
+        normalize_plane,
+        sample_line_points,
+        transform_plane,
+    )
     from synthcal.render.chessboard import render_chessboard_image
     from synthcal.render.gt import project_corners_px
+    from synthcal.render.stripe import render_stripe_image
     from synthcal.targets.chessboard import ChessboardTarget
 
     cfg = load_config(config_path)
@@ -47,10 +54,14 @@ def _cmd_preview(config_path: Path, *, frame_index: int, camera_name: str | None
                 cam_cfg = c
                 break
         if cam_cfg is None:
-            raise ValueError(f"Unknown camera {camera_name!r}; available: {[c.name for c in cfg.rig.cameras]}")
+            raise ValueError(
+                f"Unknown camera {camera_name!r}; available: {[c.name for c in cfg.rig.cameras]}"
+            )
 
     cols, rows = cfg.chessboard.inner_corners
-    target = ChessboardTarget(inner_rows=rows, inner_cols=cols, square_size_mm=cfg.chessboard.square_size_mm)
+    target = ChessboardTarget(
+        inner_rows=rows, inner_cols=cols, square_size_mm=cfg.chessboard.square_size_mm
+    )
     corners_xyz = target.corners_xyz()
 
     if cfg.scene is not None:
@@ -58,7 +69,9 @@ def _cmd_preview(config_path: Path, *, frame_index: int, camera_name: str | None
     else:
         width_mm, height_mm = target.bounds()
         T_world_target = np.eye(4, dtype=np.float64)
-        T_world_target[:3, 3] = np.array([-width_mm / 2.0, -height_mm / 2.0, 1000.0], dtype=np.float64)
+        T_world_target[:3, 3] = np.array(
+            [-width_mm / 2.0, -height_mm / 2.0, 1000.0], dtype=np.float64
+        )
 
     T_base_tcp = np.eye(4, dtype=np.float64)
     T_tcp_cam = np.asarray(cam_cfg.T_tcp_cam, dtype=np.float64)
@@ -75,23 +88,77 @@ def _cmd_preview(config_path: Path, *, frame_index: int, camera_name: str | None
 
     import matplotlib.pyplot as plt
 
-    fig, ax = plt.subplots()
-    ax.imshow(img, cmap="gray", vmin=0, vmax=255)
-    ax.set_title(f"frame={frame_index} cam={cam_cfg.name}")
+    show_laser = cfg.laser is not None and cfg.laser.enabled
+    if show_laser:
+        fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(10, 4))
+    else:
+        fig, ax0 = plt.subplots()
+        ax1 = None
+
+    ax0.imshow(img, cmap="gray", vmin=0, vmax=255)
+    ax0.set_title(f"target frame={frame_index} cam={cam_cfg.name}")
 
     if bool(np.any(visible)):
-        ax.scatter(corners_px[visible, 0], corners_px[visible, 1], s=12, c="lime", marker="o")
+        ax0.scatter(corners_px[visible, 0], corners_px[visible, 1], s=12, c="lime", marker="o")
     if bool(np.any(~visible)):
-        ax.scatter(corners_px[~visible, 0], corners_px[~visible, 1], s=12, c="red", marker="x")
+        ax0.scatter(corners_px[~visible, 0], corners_px[~visible, 1], s=12, c="red", marker="x")
 
-    ax.set_xlim([-0.5, cam.resolution[0] - 0.5])
-    ax.set_ylim([cam.resolution[1] - 0.5, -0.5])
+    ax0.set_xlim([-0.5, cam.resolution[0] - 0.5])
+    ax0.set_ylim([cam.resolution[1] - 0.5, -0.5])
+
+    if show_laser and ax1 is not None:
+        plane_tcp = normalize_plane(np.asarray(cfg.laser.plane_in_tcp, dtype=np.float64))
+        board_plane_target = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float64)
+
+        T_cam_tcp = invert_se3(T_tcp_cam)
+        plane_cam = transform_plane(T_cam_tcp, plane_tcp)
+        T_target_cam = invert_se3(T_cam_target)
+        plane_target = transform_plane(T_target_cam, plane_cam)
+
+        try:
+            p0, v = intersect_planes_to_line(plane_target, board_plane_target, eps=1e-12)
+        except ValueError:
+            stripe_px = np.zeros((0, 2), dtype=np.float32)
+            stripe_vis = np.zeros((0,), dtype=bool)
+            stripe_img = np.zeros((cam.resolution[1], cam.resolution[0]), dtype=np.uint8)
+        else:
+            width_mm, height_mm = target.bounds()
+            L = float(max(width_mm, height_mm) * 4.0)
+            num = int(max(cam.resolution) * 2)
+            pts_target = sample_line_points(p0, v, -L, L, num)
+            stripe_px, stripe_vis = project_corners_px(cam, pts_target, T_cam_target)
+            stripe_img = render_stripe_image(
+                cam,
+                stripe_px,
+                stripe_vis,
+                width_px=float(cfg.laser.stripe_width_px),
+                intensity=int(cfg.laser.stripe_intensity),
+                background=0,
+            )
+
+        ax1.imshow(stripe_img, cmap="gray", vmin=0, vmax=255)
+        ax1.set_title("stripe + centerline")
+
+        if stripe_px.size:
+            finite = np.isfinite(stripe_px[:, 0]) & np.isfinite(stripe_px[:, 1])
+            vis = stripe_vis & finite
+            inv = (~stripe_vis) & finite
+            if bool(np.any(vis)):
+                ax1.scatter(stripe_px[vis, 0], stripe_px[vis, 1], s=6, c="cyan", marker=".")
+            if bool(np.any(inv)):
+                ax1.scatter(stripe_px[inv, 0], stripe_px[inv, 1], s=10, c="red", marker="x")
+
+        ax1.set_xlim([-0.5, cam.resolution[0] - 0.5])
+        ax1.set_ylim([cam.resolution[1] - 0.5, -0.5])
+
     plt.show()
     return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="synthcal", description="Synthetic calibration dataset generator")
+    parser = argparse.ArgumentParser(
+        prog="synthcal", description="Synthetic calibration dataset generator"
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_init = sub.add_parser("init-config", help="Write an example config.yaml")
@@ -101,7 +168,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_gen.add_argument("config_yaml", type=Path, help="Input config.yaml")
     p_gen.add_argument("out_dir", type=Path, help="Output dataset directory")
 
-    p_prev = sub.add_parser("preview", help="Render a single frame/camera and show a preview window")
+    p_prev = sub.add_parser(
+        "preview", help="Render a single frame/camera and show a preview window"
+    )
     p_prev.add_argument("config_yaml", type=Path, help="Input config.yaml")
     p_prev.add_argument("--frame", type=int, default=0, help="Frame index (default: 0)")
     p_prev.add_argument(

--- a/src/synthcal/core/__init__.py
+++ b/src/synthcal/core/__init__.py
@@ -1,4 +1,3 @@
 """Core math primitives used by synthcal."""
 
 from __future__ import annotations
-

--- a/src/synthcal/laser/__init__.py
+++ b/src/synthcal/laser/__init__.py
@@ -1,0 +1,15 @@
+"""Laser-stripe geometry helpers."""
+
+from __future__ import annotations
+
+__all__ = [
+    "LaserPlane",
+    "intersect_planes_to_line",
+    "normalize_plane",
+    "sample_line_points",
+    "transform_plane",
+]
+
+from .centerline import sample_line_points
+from .intersection import intersect_planes_to_line
+from .model import LaserPlane, normalize_plane, transform_plane

--- a/src/synthcal/laser/centerline.py
+++ b/src/synthcal/laser/centerline.py
@@ -1,0 +1,50 @@
+"""Laser stripe centerline sampling helpers.
+
+All geometry is expressed in millimeters (mm).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def sample_line_points(
+    p0: Any,
+    v: Any,
+    t_min: float,
+    t_max: float,
+    num: int,
+) -> np.ndarray:
+    """Sample points along a 3D line.
+
+    The line is parameterized as `P(t) = p0 + t * v`.
+
+    Parameters
+    ----------
+    p0:
+        Point on the line, shape (3,) in mm.
+    v:
+        Line direction, shape (3,) in mm/mm (unitless). `v` does not need to be unit length.
+    t_min, t_max:
+        Range of `t` values to sample (inclusive).
+    num:
+        Number of samples (>= 2).
+
+    Returns
+    -------
+    np.ndarray
+        Sampled points with shape `(num, 3)`, float64, in mm.
+    """
+
+    if num < 2:
+        raise ValueError("num must be >= 2")
+
+    p0 = np.asarray(p0, dtype=np.float64)
+    v = np.asarray(v, dtype=np.float64)
+    if p0.shape != (3,) or v.shape != (3,):
+        raise ValueError(f"p0 and v must have shape (3,), got {p0.shape} and {v.shape}")
+
+    t = np.linspace(float(t_min), float(t_max), int(num), dtype=np.float64)
+    return p0.reshape(1, 3) + t.reshape(-1, 1) * v.reshape(1, 3)

--- a/src/synthcal/laser/intersection.py
+++ b/src/synthcal/laser/intersection.py
@@ -1,0 +1,76 @@
+"""Plane/plane intersection helpers.
+
+All geometry is expressed in millimeters (mm).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def intersect_planes_to_line(
+    plane_a: Any,
+    plane_b: Any,
+    *,
+    eps: float = 1e-12,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Intersect two non-parallel planes into a 3D line.
+
+    Parameters
+    ----------
+    plane_a, plane_b:
+        Array-like shape (4,) representing `[n_x, n_y, n_z, d]` where the plane is
+        `n·X + d = 0` (X in mm).
+    eps:
+        Threshold for detecting parallel/degenerate planes via `||n1 x n2||`.
+
+    Returns
+    -------
+    (p0, v)
+        `p0` is a point on the intersection line (shape (3,)).
+        `v` is a unit direction vector for the line (shape (3,)).
+
+    Raises
+    ------
+    ValueError
+        If the planes are parallel/degenerate.
+    """
+
+    p1 = np.asarray(plane_a, dtype=np.float64)
+    p2 = np.asarray(plane_b, dtype=np.float64)
+    if p1.shape != (4,) or p2.shape != (4,):
+        raise ValueError(f"plane_a/plane_b must have shape (4,), got {p1.shape} and {p2.shape}")
+
+    n1, d1 = p1[:3], float(p1[3])
+    n2, d2 = p2[:3], float(p2[3])
+
+    v = np.cross(n1, n2)
+    v_norm = float(np.linalg.norm(v))
+    if v_norm < eps:
+        raise ValueError("Planes are parallel or degenerate")
+    v_unit = v / v_norm
+
+    # Choose coordinate to eliminate (set to 0) based on the largest component
+    # of the intersection direction. This yields a 2x2 system with determinant
+    # equal to that component (up to sign), improving numerical stability.
+    k = int(np.argmax(np.abs(v)))
+    idx = [0, 1, 2]
+    idx.remove(k)
+    i, j = idx[0], idx[1]
+
+    A = np.array([[n1[i], n1[j]], [n2[i], n2[j]]], dtype=np.float64)
+    b = -np.array([d1, d2], dtype=np.float64)
+
+    det = float(np.linalg.det(A))
+    if abs(det) < eps:
+        raise ValueError("Degenerate plane intersection (ill-conditioned)")
+
+    sol = np.linalg.solve(A, b)
+    p0 = np.zeros(3, dtype=np.float64)
+    p0[i] = float(sol[0])
+    p0[j] = float(sol[1])
+    p0[k] = 0.0
+
+    return p0, v_unit

--- a/src/synthcal/laser/model.py
+++ b/src/synthcal/laser/model.py
@@ -1,0 +1,95 @@
+"""Laser plane model and coordinate transforms.
+
+All geometry is expressed in millimeters (mm).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from synthcal.core.geometry import as_se3, invert_se3
+
+
+@dataclass(frozen=True)
+class LaserPlane:
+    """Infinite laser plane described in the TCP frame.
+
+    The plane uses the implicit equation:
+
+        n · X + d = 0
+
+    where `X` is a 3D point in millimeters (mm).
+    """
+
+    plane_in_tcp: np.ndarray
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        plane = np.asarray(self.plane_in_tcp, dtype=np.float64)
+        if plane.shape != (4,):
+            raise ValueError(f"plane_in_tcp must have shape (4,), got {plane.shape}")
+        if self.enabled and float(np.linalg.norm(plane[:3])) <= 0.0:
+            raise ValueError("plane_in_tcp normal must be non-zero when enabled=True")
+        object.__setattr__(self, "plane_in_tcp", plane)
+
+
+def normalize_plane(plane: Any) -> np.ndarray:
+    """Return a normalized copy of a plane equation.
+
+    Parameters
+    ----------
+    plane:
+        Array-like shape (4,) representing `[n_x, n_y, n_z, d]` where the plane is
+        `n·X + d = 0` (X in mm).
+
+    Returns
+    -------
+    np.ndarray
+        Float64 array of shape (4,) where the normal `n` has unit length.
+    """
+
+    p = np.asarray(plane, dtype=np.float64)
+    if p.shape != (4,):
+        raise ValueError(f"plane must have shape (4,), got {p.shape}")
+    n = p[:3]
+    norm = float(np.linalg.norm(n))
+    if norm <= 0.0:
+        raise ValueError("plane normal must be non-zero")
+    return p / norm
+
+
+def transform_plane(T_dst_src: Any, plane_src: Any) -> np.ndarray:
+    """Transform a plane equation between coordinate frames.
+
+    Uses column-vector convention for points:
+
+        X_dst = T_dst_src @ [X_src, 1]
+
+    Plane coefficients transform as:
+
+        π_dst = (T_dst_src^{-1})^T π_src
+
+    where π = [n_x, n_y, n_z, d] and the plane is `n·X + d = 0` (X in mm).
+
+    Parameters
+    ----------
+    T_dst_src:
+        SE(3) transform mapping points from `src` to `dst`, shape (4, 4).
+    plane_src:
+        Plane coefficients in `src`, shape (4,).
+
+    Returns
+    -------
+    np.ndarray
+        Plane coefficients in `dst`, shape (4,), float64.
+    """
+
+    T = as_se3(T_dst_src)
+    p = np.asarray(plane_src, dtype=np.float64)
+    if p.shape != (4,):
+        raise ValueError(f"plane_src must have shape (4,), got {p.shape}")
+    T_inv = invert_se3(T)
+    return (T_inv.T @ p).astype(np.float64, copy=False)

--- a/src/synthcal/render/__init__.py
+++ b/src/synthcal/render/__init__.py
@@ -1,4 +1,3 @@
 """Rendering and ground-truth helpers."""
 
 from __future__ import annotations
-

--- a/src/synthcal/render/chessboard.py
+++ b/src/synthcal/render/chessboard.py
@@ -96,4 +96,3 @@ def render_chessboard_image(
     if bool(np.any(mask)):
         out[mask] = target.eval_color_xy(x[mask], y[mask])
     return out.reshape(H, W)
-

--- a/src/synthcal/render/gt.py
+++ b/src/synthcal/render/gt.py
@@ -55,4 +55,3 @@ def project_corners_px(
     in_bounds = (u >= 0.0) & (u < float(W)) & (v >= 0.0) & (v < float(H))
     visible = ok & finite & in_bounds
     return corners_px, visible.astype(bool, copy=False)
-

--- a/src/synthcal/render/stripe.py
+++ b/src/synthcal/render/stripe.py
@@ -1,0 +1,99 @@
+"""Laser stripe rasterization (v0).
+
+This module intentionally implements a simple, deterministic renderer suitable
+for preview and small/moderate datasets.
+
+All geometry upstream is expressed in millimeters (mm). This renderer operates
+purely in pixel space.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from synthcal.camera import PinholeCamera
+
+
+def render_stripe_image(
+    camera: PinholeCamera,
+    centerline_px: Any,
+    centerline_visible: Any,
+    *,
+    width_px: float,
+    intensity: int = 255,
+    background: int = 0,
+) -> np.ndarray:
+    """Render a stripe-only grayscale image by splatting a Gaussian kernel.
+
+    Parameters
+    ----------
+    camera:
+        Pinhole camera model.
+    centerline_px:
+        Array-like of shape `(M, 2)` containing projected `(u, v)` pixel coordinates.
+    centerline_visible:
+        Boolean mask of shape `(M,)` indicating which samples should contribute.
+    width_px:
+        Gaussian sigma in pixels.
+    intensity:
+        Peak intensity at the stripe center (0..255).
+    background:
+        Background grayscale intensity (0..255).
+
+    Returns
+    -------
+    np.ndarray
+        Image array of shape `(H, W)` with dtype `uint8`.
+    """
+
+    if width_px <= 0.0:
+        raise ValueError("width_px must be > 0")
+    if not (0 <= intensity <= 255):
+        raise ValueError("intensity must be in [0, 255]")
+    if not (0 <= background <= 255):
+        raise ValueError("background must be in [0, 255]")
+
+    pts = np.asarray(centerline_px, dtype=np.float64)
+    vis = np.asarray(centerline_visible, dtype=bool)
+    if pts.ndim != 2 or pts.shape[1] != 2:
+        raise ValueError(f"centerline_px must have shape (M, 2), got {pts.shape}")
+    if vis.shape != (pts.shape[0],):
+        raise ValueError(f"centerline_visible must have shape ({pts.shape[0]},), got {vis.shape}")
+
+    width_px = float(width_px)
+    sigma2 = width_px * width_px
+    r = int(math.ceil(3.0 * width_px))
+
+    W, H = camera.resolution
+    img = np.full((int(H), int(W)), float(background), dtype=np.float32)
+
+    if not bool(np.any(vis)):
+        return img.astype(np.uint8, copy=False)
+
+    peak = float(intensity)
+    base = float(background)
+    for u_f, v_f in pts[vis]:
+        if not (np.isfinite(u_f) and np.isfinite(v_f)):
+            continue
+
+        u0 = int(np.round(u_f))
+        v0 = int(np.round(v_f))
+
+        u_min = max(u0 - r, 0)
+        u_max = min(u0 + r, int(W) - 1)
+        v_min = max(v0 - r, 0)
+        v_max = min(v0 + r, int(H) - 1)
+
+        for v in range(v_min, v_max + 1):
+            dv = v - v0
+            for u in range(u_min, u_max + 1):
+                du = u - u0
+                w = math.exp(-((du * du + dv * dv) / (2.0 * sigma2)))
+                val = base + (peak - base) * float(w)
+                if val > img[v, u]:
+                    img[v, u] = val
+
+    return np.clip(img, 0.0, 255.0).astype(np.uint8, copy=False)

--- a/src/synthcal/targets/__init__.py
+++ b/src/synthcal/targets/__init__.py
@@ -5,4 +5,3 @@ from __future__ import annotations
 from .chessboard import ChessboardTarget
 
 __all__ = ["ChessboardTarget"]
-

--- a/src/synthcal/targets/chessboard.py
+++ b/src/synthcal/targets/chessboard.py
@@ -91,4 +91,3 @@ class ChessboardTarget:
         is_black = ((ix + iy) & 1) == 0
         black, white = self.colors
         return np.where(is_black, black, white).astype(np.uint8, copy=False)
-

--- a/src/synthcal/util.py
+++ b/src/synthcal/util.py
@@ -24,4 +24,3 @@ def require_ascii_filename_component(value: str, *, label: str) -> str:
             f"{label} must match {_ASCII_FILENAME_COMPONENT_RE.pattern} (got {value!r})"
         )
     return value
-

--- a/tests/test_plane_transform.py
+++ b/tests/test_plane_transform.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import numpy as np
+
+from synthcal.laser.model import normalize_plane, transform_plane
+
+
+def test_normalize_plane_scales_d() -> None:
+    plane = np.array([2.0, 0.0, 0.0, 4.0], dtype=np.float64)
+    out = normalize_plane(plane)
+    assert np.allclose(out, np.array([1.0, 0.0, 0.0, 2.0], dtype=np.float64), atol=1e-12, rtol=0.0)
+
+
+def test_transform_plane_identity_is_noop() -> None:
+    plane = np.array([0.1, -0.2, 0.3, 4.5], dtype=np.float64)
+    out = transform_plane(np.eye(4, dtype=np.float64), plane)
+    assert np.allclose(out, plane, atol=1e-12, rtol=0.0)
+
+
+def test_transform_plane_translation_along_z_updates_d() -> None:
+    T = np.eye(4, dtype=np.float64)
+    T[2, 3] = 10.0
+
+    plane = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float64)  # z=0 in src
+    out = transform_plane(T, plane)
+    assert np.allclose(
+        out, np.array([0.0, 0.0, 1.0, -10.0], dtype=np.float64), atol=1e-12, rtol=0.0
+    )
+
+
+def test_transform_plane_rotation_updates_normal() -> None:
+    # Rotate points from src -> dst by +90deg about Y.
+    T = np.eye(4, dtype=np.float64)
+    T[:3, :3] = np.array([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]], dtype=np.float64)
+
+    plane = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float64)  # z=0 in src
+    out = transform_plane(T, plane)
+    assert np.allclose(out, np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float64), atol=1e-12, rtol=0.0)

--- a/tests/test_stripe_pipeline.py
+++ b/tests/test_stripe_pipeline.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import numpy as np
+
+from synthcal.camera import PinholeCamera
+from synthcal.core.geometry import invert_se3
+from synthcal.laser import intersect_planes_to_line, sample_line_points, transform_plane
+from synthcal.render.gt import project_corners_px
+from synthcal.render.stripe import render_stripe_image
+from synthcal.targets.chessboard import ChessboardTarget
+
+
+def _make_test_scene() -> tuple[PinholeCamera, ChessboardTarget, np.ndarray]:
+    cam = PinholeCamera(
+        resolution=(640, 480),
+        K=np.array([[800.0, 0.0, 320.0], [0.0, 800.0, 240.0], [0.0, 0.0, 1.0]]),
+        dist=np.zeros(5, dtype=np.float64),
+    )
+    target = ChessboardTarget(inner_rows=6, inner_cols=9, square_size_mm=25.0)
+
+    width_mm, height_mm = target.bounds()
+    T_cam_target = np.eye(4, dtype=np.float64)
+    T_cam_target[:3, 3] = np.array([-width_mm / 2.0, -height_mm / 2.0, 1000.0], dtype=np.float64)
+    return cam, target, T_cam_target
+
+
+def _compute_stripe(
+    cam: PinholeCamera,
+    target: ChessboardTarget,
+    T_cam_target: np.ndarray,
+    plane_in_tcp: np.ndarray,
+    T_tcp_cam: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    board_plane_target = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float64)
+
+    T_cam_tcp = invert_se3(T_tcp_cam)
+    plane_cam = transform_plane(T_cam_tcp, plane_in_tcp)
+    T_target_cam = invert_se3(T_cam_target)
+    plane_target = transform_plane(T_target_cam, plane_cam)
+
+    try:
+        p0, v = intersect_planes_to_line(plane_target, board_plane_target, eps=1e-12)
+    except ValueError:
+        stripe_px = np.zeros((0, 2), dtype=np.float32)
+        stripe_vis = np.zeros((0,), dtype=bool)
+        stripe_img = np.zeros((cam.resolution[1], cam.resolution[0]), dtype=np.uint8)
+        return stripe_px, stripe_vis, stripe_img
+
+    width_mm, height_mm = target.bounds()
+    L = float(max(width_mm, height_mm) * 4.0)
+    num = int(max(cam.resolution) * 2)
+    pts_target = sample_line_points(p0, v, -L, L, num)
+    stripe_px, stripe_vis = project_corners_px(cam, pts_target, T_cam_target)
+    stripe_img = render_stripe_image(
+        cam, stripe_px, stripe_vis, width_px=3.0, intensity=255, background=0
+    )
+    return stripe_px, stripe_vis, stripe_img
+
+
+def test_stripe_centerline_and_image_shapes() -> None:
+    cam, target, T_cam_target = _make_test_scene()
+
+    width_mm, _height_mm = target.bounds()
+    plane_target = np.array([1.0, 0.0, 0.0, -width_mm / 2.0], dtype=np.float64)  # x = width/2
+    plane_tcp = transform_plane(T_cam_target, plane_target)
+
+    stripe_px, stripe_vis, stripe_img = _compute_stripe(
+        cam,
+        target,
+        T_cam_target,
+        plane_in_tcp=plane_tcp,
+        T_tcp_cam=np.eye(4, dtype=np.float64),
+    )
+
+    M = int(max(cam.resolution) * 2)
+    assert stripe_px.shape == (M, 2)
+    assert stripe_px.dtype == np.float32
+    assert stripe_vis.shape == (M,)
+    assert stripe_vis.dtype == bool
+    assert stripe_img.shape == (cam.resolution[1], cam.resolution[0])
+    assert stripe_img.dtype == np.uint8
+    assert bool(np.any(stripe_vis))
+    assert int(stripe_img.max()) > 0
+
+
+def test_parallel_planes_produce_black_and_empty() -> None:
+    cam, target, T_cam_target = _make_test_scene()
+
+    # A laser plane parallel to the target plane (z=0 in target) yields no stable intersection line.
+    plane_target = np.array([0.0, 0.0, 1.0, -1.0], dtype=np.float64)  # z = 1mm
+    plane_tcp = transform_plane(T_cam_target, plane_target)
+
+    stripe_px, stripe_vis, stripe_img = _compute_stripe(
+        cam,
+        target,
+        T_cam_target,
+        plane_in_tcp=plane_tcp,
+        T_tcp_cam=np.eye(4, dtype=np.float64),
+    )
+
+    assert stripe_px.shape == (0, 2)
+    assert stripe_vis.shape == (0,)
+    assert stripe_img.shape == (cam.resolution[1], cam.resolution[0])
+    assert int(stripe_img.max()) == 0


### PR DESCRIPTION
- Added laser stripe geometry helpers including functions for plane intersection, normalization, and sampling line points.
- Introduced a new LaserPlane model to represent laser planes in the TCP frame.
- Enhanced the dataset generation process to include laser outputs when enabled, including stripe images and centerline data.
- Updated configuration and manifest handling to support laser settings.
- Added tests for stripe rendering and plane transformations to ensure correctness.
- Cleaned up imports and removed unnecessary lines in various modules.