### PR TITLE
feat: Add configuration and manifest references for dataset generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: tests
+name: build
 
 on:
   pull_request:
@@ -7,13 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  pytest:
+  build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,14 +16,21 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Install
+      - name: Install build tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          python -m pip install build
 
-      - name: Run tests
-        run: python -m pytest
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Ruff
+        run: |
+          ruff format --check .
+          ruff check .
+
+      - name: Pytest
+        run: python -m pytest
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.1.0
+
+- Analytic chessboard rendering with GT corner projections.
+- Optional laser plane + stripe-only rendering with GT centerline exports.
+- Deterministic effects stack (blur + noise + quantize) driven by a single global seed.
+- Deterministic scenario pose sampling with in-view constraints and presets.
+- CLI commands: `init-config`, `preview`, `generate`.
+- Public API in `synthcal.api`.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 synthcal contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -1,0 +1,47 @@
+# Config reference (v1)
+
+Top-level keys:
+
+- `config_version` (int): config schema version. Supported: `1`.
+- `seed` (int): global dataset seed (determinism key).
+- `units` (object): must be `{length: "mm"}`.
+- `dataset` (object):
+  - `name` (str)
+  - `num_frames` (int): number of frames to generate (may be overridden by `scenario.num_frames`).
+- `rig` (object):
+  - `cameras` (list of objects):
+    - `name` (str, ASCII): used in output filenames (e.g. `cam00`).
+    - `image_size_px` (`[W, H]` ints)
+    - `K` (3x3 floats): OpenCV-style intrinsics
+    - `dist` (5 floats): `[k1, k2, k3, p1, p2]`
+    - `T_tcp_cam` (4x4 floats, optional): TCP→camera extrinsic, defaults to identity.
+- `chessboard` (object):
+  - `inner_corners` (`[cols, rows]` ints, both >= 2)
+  - `square_size_mm` (float > 0)
+- `effects` (object, optional):
+  - `enabled` (bool, default `true`)
+  - `blur_sigma_px` (float >= 0, default `0.0`)
+  - `noise_sigma` (float >= 0, default `0.0`)
+  - `clamp_min` (float, default `0.0`)
+  - `clamp_max` (float, default `255.0`)
+  - Note: blur uses SciPy when available (`pip install "synthcal[scipy]"`); otherwise a deterministic NumPy fallback is used.
+- `laser` (object, optional):
+  - `enabled` (bool, default `false`)
+  - `plane_in_tcp` (`[nx, ny, nz, d]` floats): plane equation `n·X + d = 0` in TCP frame (X in mm)
+  - `stripe_width_px` (int > 0, default `3`)
+  - `stripe_intensity` (int in `[1..255]` when enabled, default `255`)
+- `scenario` (object, optional): enables per-frame pose sampling and in-view constraints
+  - `preset` (`"easy" | "medium" | "hard"`, optional)
+  - `num_frames` (int > 0, optional)
+  - `distance_mm` (object `{min,max}`; `min > 0`)
+  - `tilt_deg` (object `{min,max}`; `0 <= min <= max <= 89`)
+  - `yaw_deg` (object `{min,max}`)
+  - `roll_deg` (object `{min,max}`)
+  - `xy_offset_frac` (object `{min,max}`): fractions of board width/height for the look-at point offset
+  - `in_view` (object):
+    - `margin_px` (int >= 0, default `20`)
+    - `require_all_cameras` (bool, default `true`)
+    - `min_cameras_visible` (int > 0, default `1`)
+  - `max_attempts_per_frame` (int > 0, default depends on preset)
+- `scene` (object, optional):
+  - `T_world_target` (4x4 floats): world/base → target pose (mm)

--- a/docs/manifest_reference.md
+++ b/docs/manifest_reference.md
@@ -1,0 +1,19 @@
+# Manifest reference (v1)
+
+The manifest is a stable description of a generated dataset. Paths stored in the manifest are
+relative to the dataset root directory.
+
+Top-level keys:
+
+- `version` (int): schema version (currently `1`).
+- `manifest_version` (int): schema version (currently `1`, kept for backward compatibility).
+- `created_utc` (str): ISO-8601 UTC timestamp.
+- `generator` (object): `{name, version}`.
+- `seed` (int): global dataset seed used.
+- `units` (object): `{length: "mm"}`.
+- `dataset` (object): `{name, num_frames}`.
+- `paths` (object): key dataset paths (`config_yaml`, `manifest_yaml`, `rig_yaml`, `cameras_dir`, `frames_dir`).
+- `cameras` (list): per-camera metadata (`name`, `intrinsics_yaml`, `image_size_px`).
+- `layout` (object): filename patterns for per-frame/per-camera outputs.
+- `laser` (object, optional): present only when laser outputs were generated.
+

--- a/examples/minimal_no_laser.yaml
+++ b/examples/minimal_no_laser.yaml
@@ -1,0 +1,31 @@
+config_version: 1
+seed: 0
+units:
+  length: mm
+dataset:
+  name: minimal_no_laser
+  num_frames: 1
+rig:
+  cameras:
+    - name: cam00
+      image_size_px: [640, 480]
+      K:
+        - [800.0, 0.0, 320.0]
+        - [0.0, 800.0, 240.0]
+        - [0.0, 0.0, 1.0]
+      dist: [0.0, 0.0, 0.0, 0.0, 0.0]
+      T_tcp_cam:
+        - [1.0, 0.0, 0.0, 0.0]
+        - [0.0, 1.0, 0.0, 0.0]
+        - [0.0, 0.0, 1.0, 0.0]
+        - [0.0, 0.0, 0.0, 1.0]
+chessboard:
+  inner_corners: [9, 6]
+  square_size_mm: 25.0
+effects:
+  enabled: true
+  blur_sigma_px: 0.0
+  noise_sigma: 0.0
+  clamp_min: 0.0
+  clamp_max: 255.0
+

--- a/examples/minimal_with_laser.yaml
+++ b/examples/minimal_with_laser.yaml
@@ -1,0 +1,36 @@
+config_version: 1
+seed: 0
+units:
+  length: mm
+dataset:
+  name: minimal_with_laser
+  num_frames: 1
+rig:
+  cameras:
+    - name: cam00
+      image_size_px: [640, 480]
+      K:
+        - [800.0, 0.0, 320.0]
+        - [0.0, 800.0, 240.0]
+        - [0.0, 0.0, 1.0]
+      dist: [0.0, 0.0, 0.0, 0.0, 0.0]
+      T_tcp_cam:
+        - [1.0, 0.0, 0.0, 0.0]
+        - [0.0, 1.0, 0.0, 0.0]
+        - [0.0, 0.0, 1.0, 0.0]
+        - [0.0, 0.0, 0.0, 1.0]
+chessboard:
+  inner_corners: [9, 6]
+  square_size_mm: 25.0
+effects:
+  enabled: true
+  blur_sigma_px: 0.0
+  noise_sigma: 0.0
+  clamp_min: 0.0
+  clamp_max: 255.0
+laser:
+  enabled: true
+  plane_in_tcp: [1.0, 0.0, 0.0, 0.0]
+  stripe_width_px: 3
+  stripe_intensity: 255
+

--- a/examples/multicam_medium.yaml
+++ b/examples/multicam_medium.yaml
@@ -1,0 +1,45 @@
+config_version: 1
+seed: 0
+units:
+  length: mm
+dataset:
+  name: multicam_medium
+  num_frames: 10
+rig:
+  cameras:
+    - name: cam00
+      image_size_px: [640, 480]
+      K:
+        - [800.0, 0.0, 320.0]
+        - [0.0, 800.0, 240.0]
+        - [0.0, 0.0, 1.0]
+      dist: [0.0, 0.0, 0.0, 0.0, 0.0]
+      T_tcp_cam:
+        - [1.0, 0.0, 0.0, 0.0]
+        - [0.0, 1.0, 0.0, 0.0]
+        - [0.0, 0.0, 1.0, 0.0]
+        - [0.0, 0.0, 0.0, 1.0]
+    - name: cam01
+      image_size_px: [640, 480]
+      K:
+        - [800.0, 0.0, 320.0]
+        - [0.0, 800.0, 240.0]
+        - [0.0, 0.0, 1.0]
+      dist: [0.0, 0.0, 0.0, 0.0, 0.0]
+      T_tcp_cam:
+        - [1.0, 0.0, 0.0, 100.0]
+        - [0.0, 1.0, 0.0, 0.0]
+        - [0.0, 0.0, 1.0, 0.0]
+        - [0.0, 0.0, 0.0, 1.0]
+chessboard:
+  inner_corners: [9, 6]
+  square_size_mm: 25.0
+effects:
+  enabled: true
+  blur_sigma_px: 0.0
+  noise_sigma: 0.0
+  clamp_min: 0.0
+  clamp_max: 255.0
+scenario:
+  preset: medium
+  num_frames: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,18 +8,37 @@ version = "0.1.0"
 description = "Synthetic dataset generator for camera + laser-stripe calibration."
 readme = "README.md"
 requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "synthcal contributors" }]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering",
+]
 dependencies = [
   "numpy>=1.23",
   "PyYAML>=6.0",
   "Pillow>=10.0",
-  "scipy>=1.10",
   "matplotlib>=3.7",
 ]
+
+[project.scripts]
+synthcal = "synthcal.cli:main"
 
 [project.optional-dependencies]
 dev = [
   "pytest>=7.4",
   "ruff>=0.5",
+  "build>=1.0",
+]
+scipy = [
+  "scipy>=1.10",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/synthcal/__init__.py
+++ b/src/synthcal/__init__.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "generate_dataset",
+    "generate_dataset_from_config",
+    "render_frame_preview",
+]
 
 __version__ = "0.1.0"
+
+from .api import generate_dataset, generate_dataset_from_config, render_frame_preview  # noqa: E402

--- a/src/synthcal/api.py
+++ b/src/synthcal/api.py
@@ -1,0 +1,180 @@
+"""Public API for synthcal.
+
+The functions in this module are the supported, stable entry points for using synthcal as a
+library. Internal modules may change without notice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from synthcal.camera import PinholeCamera
+from synthcal.core.geometry import invert_se3
+from synthcal.core.seeding import derive_rng
+from synthcal.effects.pipeline import apply_effects
+from synthcal.io.config import SynthCalConfig, load_config
+from synthcal.io.generate import generate_dataset as _generate_dataset_from_config
+from synthcal.laser import (
+    intersect_planes_to_line,
+    normalize_plane,
+    sample_line_points,
+    transform_plane,
+)
+from synthcal.render.chessboard import render_chessboard_image
+from synthcal.render.gt import project_corners_px
+from synthcal.render.stripe import render_stripe_image
+from synthcal.scenario.sampling import sample_valid_T_base_tcp
+from synthcal.targets.chessboard import ChessboardTarget
+
+
+def generate_dataset(config_path: str | Path, out_dir: str | Path) -> Path:
+    """Generate a dataset from a config file on disk."""
+
+    cfg = load_config(config_path)
+    return generate_dataset_from_config(cfg, out_dir)
+
+
+def generate_dataset_from_config(config_obj: SynthCalConfig, out_dir: str | Path) -> Path:
+    """Generate a dataset from an in-memory config object."""
+
+    out_path = Path(out_dir)
+    _generate_dataset_from_config(config_obj, out_path)
+    return out_path
+
+
+def _default_T_world_target(target: ChessboardTarget) -> np.ndarray:
+    width_mm, height_mm = target.bounds()
+    T = np.eye(4, dtype=np.float64)
+    T[:3, 3] = np.array([-width_mm / 2.0, -height_mm / 2.0, 1000.0], dtype=np.float64)
+    return T
+
+
+def render_frame_preview(config_obj: SynthCalConfig, frame_id: int) -> dict[str, Any]:
+    """Render one frame worth of images and geometric ground truth.
+
+    Returns a nested dict:
+    - `T_base_tcp`: float64 (4,4)
+    - `visibility`: dict(cam_name -> bool) (present only when scenario is enabled)
+    - `cameras[cam_name]`: per-camera images/GT arrays
+    """
+
+    cfg = config_obj
+    if not (0 <= frame_id < cfg.dataset.num_frames):
+        raise ValueError(f"frame_id must be in [0, {cfg.dataset.num_frames - 1}]")
+
+    cols, rows = cfg.chessboard.inner_corners
+    target = ChessboardTarget(
+        inner_rows=rows, inner_cols=cols, square_size_mm=cfg.chessboard.square_size_mm
+    )
+    corners_xyz = target.corners_xyz()
+
+    if cfg.scene is not None:
+        T_world_target = np.asarray(cfg.scene.T_world_target, dtype=np.float64)
+    else:
+        T_world_target = _default_T_world_target(target)
+
+    camera_models: dict[str, PinholeCamera] = {}
+    rig_T_tcp_cam: dict[str, np.ndarray] = {}
+    for cam_cfg in cfg.rig.cameras:
+        camera_models[cam_cfg.name] = PinholeCamera(
+            resolution=cam_cfg.image_size_px,
+            K=np.asarray(cam_cfg.K, dtype=np.float64),
+            dist=np.asarray(cam_cfg.dist, dtype=np.float64),
+        )
+        rig_T_tcp_cam[cam_cfg.name] = np.asarray(cam_cfg.T_tcp_cam, dtype=np.float64)
+
+    vis_by_cam: dict[str, bool] | None = None
+    if cfg.scenario is None:
+        T_base_tcp = np.eye(4, dtype=np.float64)
+    else:
+        reference_cam = cfg.rig.cameras[0].name
+        T_base_tcp, vis = sample_valid_T_base_tcp(
+            global_seed=cfg.seed,
+            frame_id=frame_id,
+            scenario=cfg.scenario,
+            cameras=camera_models,
+            rig_extrinsics=rig_T_tcp_cam,
+            target=target,
+            T_world_target=T_world_target,
+            reference_camera=reference_cam,
+        )
+        vis_by_cam = vis
+
+    laser_enabled = cfg.laser is not None and cfg.laser.enabled
+    laser_plane_tcp = None
+    if laser_enabled:
+        laser_plane_tcp = normalize_plane(np.asarray(cfg.laser.plane_in_tcp, dtype=np.float64))
+    board_plane_target = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float64)
+
+    out: dict[str, Any] = {
+        "frame_index": frame_id,
+        "T_base_tcp": T_base_tcp,
+        "cameras": {},
+    }
+    if vis_by_cam is not None:
+        out["visibility"] = dict(vis_by_cam)
+
+    for cam_cfg in cfg.rig.cameras:
+        cam = camera_models[cam_cfg.name]
+        T_tcp_cam = rig_T_tcp_cam[cam_cfg.name]
+
+        T_world_cam = T_base_tcp @ T_tcp_cam
+        T_cam_target = invert_se3(T_world_cam) @ T_world_target
+
+        img_target = render_chessboard_image(cam, target, T_cam_target)
+        rng_target = derive_rng(cfg.seed, frame_id, cam_cfg.name, "target")
+        img_target = apply_effects(img_target, cfg.effects, rng_target)
+
+        corners_px, corners_visible = project_corners_px(cam, corners_xyz, T_cam_target)
+
+        cam_out: dict[str, Any] = {
+            "T_cam_target": T_cam_target,
+            "target_image_u8": img_target,
+            "corners_px": corners_px,
+            "corners_visible": corners_visible,
+        }
+
+        if laser_plane_tcp is not None:
+            T_cam_tcp = invert_se3(T_tcp_cam)
+            plane_cam = transform_plane(T_cam_tcp, laser_plane_tcp)
+            T_target_cam = invert_se3(T_cam_target)
+            plane_target = transform_plane(T_target_cam, plane_cam)
+
+            try:
+                p0, v = intersect_planes_to_line(plane_target, board_plane_target, eps=1e-12)
+            except ValueError:
+                stripe_px = np.zeros((0, 2), dtype=np.float32)
+                stripe_vis = np.zeros((0,), dtype=bool)
+                stripe_img = np.zeros((cam.resolution[1], cam.resolution[0]), dtype=np.uint8)
+            else:
+                width_mm, height_mm = target.bounds()
+                L = float(max(width_mm, height_mm) * 4.0)
+                num = int(max(cam.resolution) * 2)
+                pts_target = sample_line_points(p0, v, -L, L, num)
+                stripe_px, stripe_vis = project_corners_px(cam, pts_target, T_cam_target)
+                stripe_img = render_stripe_image(
+                    cam,
+                    stripe_px,
+                    stripe_vis,
+                    width_px=float(cfg.laser.stripe_width_px),
+                    intensity=int(cfg.laser.stripe_intensity),
+                    background=0,
+                )
+
+            rng_stripe = derive_rng(cfg.seed, frame_id, cam_cfg.name, "stripe")
+            stripe_img = apply_effects(stripe_img, cfg.effects, rng_stripe)
+
+            cam_out.update(
+                {
+                    "stripe_image_u8": stripe_img,
+                    "stripe_centerline_px": stripe_px,
+                    "stripe_centerline_visible": stripe_vis,
+                }
+            )
+
+        out["cameras"][cam_cfg.name] = cam_out
+
+    return out

--- a/src/synthcal/cli.py
+++ b/src/synthcal/cli.py
@@ -6,6 +6,7 @@ Entry point: `python -m synthcal ...`
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 from pathlib import Path
 from typing import Any
@@ -112,7 +113,7 @@ def _cmd_preview(
             reference_camera=reference_cam,
         )
         vis_str = ", ".join(f"{k}={int(v)}" for k, v in sorted(vis_by_cam.items()))
-        print(f"scenario visibility: {vis_str}")
+        logging.info("scenario visibility: %s", vis_str)
 
     import matplotlib.pyplot as plt
 
@@ -266,6 +267,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="synthcal", description="Synthetic calibration dataset generator"
     )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity (default: INFO)",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_init = sub.add_parser("init-config", help="Write an example config.yaml")
@@ -307,6 +315,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format="%(levelname)s: %(message)s",
+    )
     try:
         if args.command == "init-config":
             return _cmd_init_config(args.path)

--- a/src/synthcal/io/manifest.py
+++ b/src/synthcal/io/manifest.py
@@ -287,7 +287,10 @@ class SynthCalManifest:
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> SynthCalManifest:
         data = _require_mapping(data, label="manifest")
-        version = _require_int(data.get("manifest_version"), label="manifest_version")
+        version_raw = data.get("manifest_version", None)
+        if version_raw is None:
+            version_raw = data.get("version", None)
+        version = _require_int(version_raw, label="manifest_version")
         if version != 1:
             raise ManifestError(f"Unsupported manifest_version {version}; expected 1")
 
@@ -322,6 +325,7 @@ class SynthCalManifest:
 
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {
+            "version": self.manifest_version,
             "manifest_version": self.manifest_version,
             "created_utc": self.created_utc,
             "generator": self.generator.to_dict(),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_init_config_writes_loadable_yaml(tmp_path: Path) -> None:
     _run_module(["init-config", str(config_path)])
 
     cfg = load_config(config_path)
-    assert cfg.version == 1
+    assert cfg.config_version == 1
     assert isinstance(cfg.seed, int)
     assert cfg.rig.cameras
 

--- a/tests/test_config_validation_and_api.py
+++ b/tests/test_config_validation_and_api.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+from synthcal.api import generate_dataset, render_frame_preview
+from synthcal.io.config import ConfigError, load_config
+
+
+def _minimal_config_dict(*, with_laser: bool) -> dict:
+    cfg: dict = {
+        "config_version": 1,
+        "seed": 0,
+        "units": {"length": "mm"},
+        "dataset": {"name": "test_dataset", "num_frames": 1},
+        "rig": {
+            "cameras": [
+                {
+                    "name": "cam00",
+                    "image_size_px": [160, 120],
+                    "K": [[200.0, 0.0, 80.0], [0.0, 200.0, 60.0], [0.0, 0.0, 1.0]],
+                    "dist": [0.0, 0.0, 0.0, 0.0, 0.0],
+                    "T_tcp_cam": [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0],
+                    ],
+                }
+            ]
+        },
+        "chessboard": {"inner_corners": [5, 4], "square_size_mm": 25.0},
+        "effects": {"enabled": True, "blur_sigma_px": 0.0, "noise_sigma": 0.0},
+    }
+    if with_laser:
+        cfg["laser"] = {
+            "enabled": True,
+            "plane_in_tcp": [1.0, 0.0, 0.0, 0.0],
+            "stripe_width_px": 2,
+            "stripe_intensity": 255,
+        }
+    return cfg
+
+
+def test_load_config_missing_config_version_warns_and_assumes_v1(tmp_path: Path) -> None:
+    cfg = _minimal_config_dict(with_laser=False)
+    cfg.pop("config_version")
+    cfg["version"] = 1
+
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        out = load_config(path)
+
+    assert out.config_version == 1
+    assert any("config_version missing" in str(w.message) for w in rec)
+
+
+def test_load_config_rejects_unsupported_config_version(tmp_path: Path) -> None:
+    cfg = _minimal_config_dict(with_laser=False)
+    cfg["config_version"] = 2
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="Unsupported config_version"):
+        load_config(path)
+
+
+def test_load_config_validates_units_mm(tmp_path: Path) -> None:
+    cfg = _minimal_config_dict(with_laser=False)
+    cfg["units"]["length"] = "cm"
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="units\\.length must be 'mm'"):
+        load_config(path)
+
+
+def test_load_config_validates_chessboard_min_size(tmp_path: Path) -> None:
+    cfg = _minimal_config_dict(with_laser=False)
+    cfg["chessboard"]["inner_corners"] = [1, 4]
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="inner_corners"):
+        load_config(path)
+
+
+def test_load_config_validates_scenario_tilt_upper_bound(tmp_path: Path) -> None:
+    cfg = _minimal_config_dict(with_laser=False)
+    cfg["scenario"] = {"tilt_deg": {"min": 0.0, "max": 90.0}}
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="scenario\\.tilt_deg\\.max"):
+        load_config(path)
+
+
+def test_load_config_validates_laser_intensity_when_enabled(tmp_path: Path) -> None:
+    cfg = _minimal_config_dict(with_laser=True)
+    cfg["laser"]["stripe_intensity"] = 0
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="laser\\.stripe_intensity"):
+        load_config(path)
+
+
+def test_example_configs_load() -> None:
+    root = Path(__file__).resolve().parents[1]
+    examples_dir = root / "examples"
+    paths = sorted(examples_dir.glob("*.yaml"))
+    assert paths, "No example configs found in examples/"
+    for p in paths:
+        cfg = load_config(p)
+        assert cfg.config_version == 1
+
+
+def test_api_generate_dataset_end_to_end_no_laser(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(_minimal_config_dict(with_laser=False), sort_keys=False), encoding="utf-8"
+    )
+
+    out_dir = tmp_path / "out"
+    out = generate_dataset(cfg_path, out_dir)
+    assert out == out_dir
+    assert (out_dir / "manifest.yaml").is_file()
+    assert (out_dir / "frames" / "frame_000000" / "cam00_target.png").is_file()
+    assert not (out_dir / "frames" / "frame_000000" / "cam00_stripe.png").exists()
+
+
+def test_api_generate_dataset_end_to_end_with_laser(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(_minimal_config_dict(with_laser=True), sort_keys=False), encoding="utf-8"
+    )
+
+    out_dir = tmp_path / "out"
+    generate_dataset(cfg_path, out_dir)
+    frame_dir = out_dir / "frames" / "frame_000000"
+    assert (frame_dir / "cam00_stripe.png").is_file()
+    assert (frame_dir / "cam00_stripe_centerline_px.npy").is_file()
+    assert (frame_dir / "cam00_stripe_centerline_visible.npy").is_file()
+
+
+def test_api_render_frame_preview_returns_arrays(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(_minimal_config_dict(with_laser=True), sort_keys=False), encoding="utf-8"
+    )
+    cfg = load_config(cfg_path)
+
+    out = render_frame_preview(cfg, 0)
+    assert out["frame_index"] == 0
+    assert out["T_base_tcp"].shape == (4, 4)
+
+    cams = out["cameras"]
+    assert "cam00" in cams
+    cam00 = cams["cam00"]
+
+    assert cam00["target_image_u8"].dtype == np.uint8
+    assert cam00["corners_px"].shape[1] == 2
+    assert cam00["corners_visible"].dtype == bool
+
+    assert cam00["stripe_image_u8"].dtype == np.uint8
+    assert cam00["stripe_centerline_px"].shape[1] == 2
+    assert cam00["stripe_centerline_visible"].dtype == bool

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -27,6 +27,19 @@ def test_effects_blur_spreads_impulse() -> None:
     assert int(out.max()) < 255
 
 
+def test_effects_blur_numpy_fallback(monkeypatch: object) -> None:
+    import synthcal.effects.pipeline as pipeline
+
+    monkeypatch.setattr(pipeline, "_gaussian_filter", None)
+
+    img = np.zeros((21, 21), dtype=np.uint8)
+    img[10, 10] = 255
+
+    cfg = EffectsConfig(enabled=True, blur_sigma_px=1.0, noise_sigma=0.0)
+    out = pipeline.apply_effects(img, cfg, rng=None)
+    assert int(np.count_nonzero(out)) > 1
+
+
 def test_effects_noise_is_deterministic_per_modality() -> None:
     img = np.full((32, 32), 128, dtype=np.uint8)
     cfg = EffectsConfig(enabled=True, blur_sigma_px=0.0, noise_sigma=10.0)


### PR DESCRIPTION
- Introduced `config_reference.md` and `manifest_reference.md` to document the schema and structure of configuration and manifest files.
- Added example YAML configurations for minimal setups with and without laser effects.
- Enhanced the `pyproject.toml` to include license and author information, and added a script entry point for the CLI.
- Implemented a public API in `api.py` for generating datasets and rendering frame previews.
- Updated the CLI to support logging levels and improved visibility of scenario outputs.
- Enhanced the effects pipeline to include a fallback for Gaussian blur when SciPy is not available.
- Improved configuration validation to ensure proper schema adherence and added warnings for deprecated fields.
- Added comprehensive tests for configuration loading, API functionality, and effects processing.